### PR TITLE
Fix issue with connectivity to Mongo

### DIFF
--- a/mongodb/init.sh
+++ b/mongodb/init.sh
@@ -30,4 +30,4 @@ gosu mongodb mongod "$@"
 
 echo "restarting with auth on"
 sleep 5
-exec gosu mongodb mongod --auth "$@"
+exec gosu mongodb /usr/local/bin/docker-entrypoint.sh --auth "$@"


### PR DESCRIPTION
Fix issue with MongoDB connectivity.
If start Mongo by command **mongod** (from version 3.6) it will use 127.0.0.1 interface.


Official MongoDB docker image starts by script **/usr/local/bin/docker-entrypoint.sh**
```
COPY docker-entrypoint.sh /usr/local/bin/
ENTRYPOINT ["docker-entrypoint.sh"]
```
In official [DockerFile](https://github.com/docker-library/mongo/blob/621a206bca04c06ad3e0d8459c9d23223ea11a01/3.7/Dockerfile)

By default params this script will start Mongo by command **mongod--bind_ip_all**.