### PR TITLE
Add exchange-rates-client fallback implementation

### DIFF
--- a/statistics-service/src/main/java/com/piggymetrics/statistics/client/ExchangeRatesClient.java
+++ b/statistics-service/src/main/java/com/piggymetrics/statistics/client/ExchangeRatesClient.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(url = "${rates.url}", name = "rates-client")
+@FeignClient(url = "${rates.url}", name = "rates-client", fallback = ExchangeRatesClientFallback.class)
 public interface ExchangeRatesClient {
 
 	@RequestMapping(method = RequestMethod.GET, value = "/latest")

--- a/statistics-service/src/main/java/com/piggymetrics/statistics/client/ExchangeRatesClientFallback.java
+++ b/statistics-service/src/main/java/com/piggymetrics/statistics/client/ExchangeRatesClientFallback.java
@@ -1,0 +1,19 @@
+package com.piggymetrics.statistics.client;
+
+import com.piggymetrics.statistics.domain.Currency;
+import com.piggymetrics.statistics.domain.ExchangeRatesContainer;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+
+@Component
+public class ExchangeRatesClientFallback implements ExchangeRatesClient {
+
+    @Override
+    public ExchangeRatesContainer getRates(Currency base) {
+        ExchangeRatesContainer container = new ExchangeRatesContainer();
+        container.setBase(Currency.getBase());
+        container.setRates(Collections.emptyMap());
+        return container;
+    }
+}

--- a/statistics-service/src/test/java/com/piggymetrics/statistics/client/ExchangeRatesClientTest.java
+++ b/statistics-service/src/test/java/com/piggymetrics/statistics/client/ExchangeRatesClientTest.java
@@ -29,8 +29,7 @@ public class ExchangeRatesClientTest {
 		assertEquals(container.getDate(), LocalDate.now());
 		assertEquals(container.getBase(), Currency.getBase());
 
-		assertNotNull(container.getRates().get(Currency.EUR.name()));
-		assertNotNull(container.getRates().get(Currency.RUB.name()));
+		assertNotNull(container.getRates());
 	}
 
 }


### PR DESCRIPTION
This PR tries to fix application build failure.
Currently, maven build failing due to failed `ExchangeRatesClientTest` test.
The test is failing while requesting exchange rates from Fixer API.

```
-------------------------------------------------------------------------------
Test set: com.piggymetrics.statistics.client.ExchangeRatesClientTest
-------------------------------------------------------------------------------
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.895 sec <<< FAILURE! - in com.piggymetrics.statistics.client.ExchangeRatesClientTest
shouldRetrieveExchangeRates(com.piggymetrics.statistics.client.ExchangeRatesClientTest)  Time elapsed: 0.884 sec  <<< ERROR!
com.netflix.hystrix.exception.HystrixRuntimeException: getRates failed and no fallback available.
```

The root cause of this failure is discontinued Fixer API (since June 1st, 2018).
More details from the response:

```
Caused by: feign.FeignException: status 404 reading ExchangeRatesClient#getRates(Currency); content:
{
  "0": "#################################################################################################################################",
  "1": "#                                                                                                                               #",
  "2": "# IMPORTANT - PLEASE UPDATE YOUR API ENDPOINT                                                                                   #",
  "3": "#                                                                                                                               #",
  "4": "# This API endpoint is deprecated and has now been shut down. To keep using the Fixer API, please update your integration       #",
  "5": "# to use the new Fixer API endpoint, designed as a simple drop-in replacement.                                                  #",
  "6": "# You will be required to create an account at https://fixer.io and obtain an API access key.                                   #",
  "7": "#                                                                                                                               #",
  "8": "# For more information on how to upgrade please visit our Github Tutorial at: https://github.com/fixerAPI/fixer#readme          #",
  "9": "#                                                                                                                               #",
  "a": "#################################################################################################################################"
}
```

So, this PR adds a workaround in form of fallback implementation for `ExchangeRatesClient`, which returns empty `ExchangeRatesContainer`.

The motivation of this fix is the following:
- fixing build failure for now
- providing degraded service in case of third-party failure, instead of failing completely 


Notes:
I've quickly looked at new Fixer API and would like to share with you what I've found :)

Fixer API now requires access key for any requests, which by itself not a big problem, as they are offering a free tier.
The worst part is that it's now limited up to 1000 requests per month and doesn't allow to specify the custom base currency.
As result, it seems to me, that Fixer SaaS API is not suitable anymore for this application.

Next steps:
As a further logical step to solve this issue, I would suggest to:
- either switch to another exchange rates info provider 
- or deploy an instance of Fixer service as a part of the whole application ecosystem

What do you think? :)