### PR TITLE
Switch exchange-rates provider

### DIFF
--- a/config/src/main/resources/shared/statistics-service.yml
+++ b/config/src/main/resources/shared/statistics-service.yml
@@ -21,4 +21,4 @@ server:
   port: 7000
 
 rates:
-  url: http://api.fixer.io
+  url: https://exchangeratesapi.io/api

--- a/statistics-service/src/main/java/com/piggymetrics/statistics/client/ExchangeRatesClient.java
+++ b/statistics-service/src/main/java/com/piggymetrics/statistics/client/ExchangeRatesClient.java
@@ -7,10 +7,19 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 @FeignClient(url = "${rates.url}", name = "rates-client", fallback = ExchangeRatesClientFallback.class)
 public interface ExchangeRatesClient {
 
+	default ExchangeRatesContainer getRates(Currency base) {
+		return getRates(base, Arrays.asList(Currency.values()));
+	}
+
 	@RequestMapping(method = RequestMethod.GET, value = "/latest")
-	ExchangeRatesContainer getRates(@RequestParam("base") Currency base);
+	ExchangeRatesContainer getRates(
+			@RequestParam("base") Currency base,
+			@RequestParam("symbols") Collection<Currency> currencies);
 
 }

--- a/statistics-service/src/main/java/com/piggymetrics/statistics/client/ExchangeRatesClientFallback.java
+++ b/statistics-service/src/main/java/com/piggymetrics/statistics/client/ExchangeRatesClientFallback.java
@@ -4,13 +4,14 @@ import com.piggymetrics.statistics.domain.Currency;
 import com.piggymetrics.statistics.domain.ExchangeRatesContainer;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
 import java.util.Collections;
 
 @Component
 public class ExchangeRatesClientFallback implements ExchangeRatesClient {
 
     @Override
-    public ExchangeRatesContainer getRates(Currency base) {
+    public ExchangeRatesContainer getRates(Currency base, Collection<Currency> currencies) {
         ExchangeRatesContainer container = new ExchangeRatesContainer();
         container.setBase(Currency.getBase());
         container.setRates(Collections.emptyMap());

--- a/statistics-service/src/test/java/com/piggymetrics/statistics/client/ExchangeRatesClientTest.java
+++ b/statistics-service/src/test/java/com/piggymetrics/statistics/client/ExchangeRatesClientTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.time.LocalDate;
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -30,8 +31,24 @@ public class ExchangeRatesClientTest {
 		assertEquals(container.getBase(), Currency.getBase());
 
 		assertNotNull(container.getRates());
+		assertEquals(Currency.values().length, container.getRates().size());
+		assertNotNull(container.getRates().get(Currency.USD.name()));
 		assertNotNull(container.getRates().get(Currency.EUR.name()));
 		assertNotNull(container.getRates().get(Currency.RUB.name()));
+	}
+
+	@Test
+	public void shouldRetrieveExchangeRatesForSpecifiedCurrency() {
+
+		Currency requestedCurrency = Currency.EUR;
+		ExchangeRatesContainer container = client.getRates(Currency.getBase(), Collections.singleton(requestedCurrency));
+
+		assertEquals(container.getDate(), LocalDate.now());
+		assertEquals(container.getBase(), Currency.getBase());
+
+		assertNotNull(container.getRates());
+		assertEquals(1, container.getRates().size());
+		assertNotNull(container.getRates().get(requestedCurrency.name()));
 	}
 
 }

--- a/statistics-service/src/test/java/com/piggymetrics/statistics/client/ExchangeRatesClientTest.java
+++ b/statistics-service/src/test/java/com/piggymetrics/statistics/client/ExchangeRatesClientTest.java
@@ -30,6 +30,8 @@ public class ExchangeRatesClientTest {
 		assertEquals(container.getBase(), Currency.getBase());
 
 		assertNotNull(container.getRates());
+		assertNotNull(container.getRates().get(Currency.EUR.name()));
+		assertNotNull(container.getRates().get(Currency.RUB.name()));
 	}
 
 }

--- a/statistics-service/src/test/resources/application.yml
+++ b/statistics-service/src/test/resources/application.yml
@@ -13,4 +13,4 @@ spring:
       port: 0
 
 rates:
-  url: http://api.fixer.io
+  url: https://exchangeratesapi.io/api


### PR DESCRIPTION
As discussed in [ PR#24 ](https://github.com/sqshq/PiggyMetrics/pull/23) this PR switches the exchange-rates client to another rates provider.

After a quick research, I've found https://exchangeratesapi.io as the most suitable alternative.
It's free, opensource, doesn't require any access tokens and even claimed to be compatible with http://fixer.io api.

There is one more commit, which adds an overloaded method to the exchange-rates client, with 'symbols' request parameter.
Moreover, I've changed the behavior of existing get-rates method - it's now requesting rates for known currencies only.
IMO, it may have (tiny) positive impact on system performance, as it reduces network traffic :) 

@sqshq what do you think about it?