### PR TITLE
Feature/turbine stream service

### DIFF
--- a/account-service/pom.xml
+++ b/account-service/pom.xml
@@ -58,6 +58,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-netflix-hystrix</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-netflix-hystrix-stream</artifactId>
 		</dependency>
 		<dependency>

--- a/account-service/src/main/java/com/piggymetrics/account/AccountApplication.java
+++ b/account-service/src/main/java/com/piggymetrics/account/AccountApplication.java
@@ -2,6 +2,7 @@ package com.piggymetrics.account;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -11,6 +12,7 @@ import org.springframework.security.oauth2.config.annotation.web.configuration.E
 @EnableDiscoveryClient
 @EnableOAuth2Client
 @EnableFeignClients
+@EnableCircuitBreaker
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class AccountApplication {
 

--- a/account-service/src/main/java/com/piggymetrics/account/client/StatisticsServiceClient.java
+++ b/account-service/src/main/java/com/piggymetrics/account/client/StatisticsServiceClient.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-@FeignClient(name = "statistics-service")
+@FeignClient(name = "statistics-service", fallback = StatisticsServiceClientFallback.class)
 public interface StatisticsServiceClient {
 
 	@RequestMapping(method = RequestMethod.PUT, value = "/statistics/{accountName}", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)

--- a/account-service/src/main/java/com/piggymetrics/account/client/StatisticsServiceClientFallback.java
+++ b/account-service/src/main/java/com/piggymetrics/account/client/StatisticsServiceClientFallback.java
@@ -1,0 +1,18 @@
+package com.piggymetrics.account.client;
+
+import com.piggymetrics.account.domain.Account;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author cdov
+ */
+@Component
+public class StatisticsServiceClientFallback implements StatisticsServiceClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StatisticsServiceClientFallback.class);
+    @Override
+    public void updateStatistics(String accountName, Account account) {
+        LOGGER.error("Error during update statistics for account: {}", accountName);
+    }
+}

--- a/config/src/main/resources/shared/account-service.yml
+++ b/config/src/main/resources/shared/account-service.yml
@@ -20,3 +20,7 @@ server:
   servlet:
     context-path: /accounts
   port: 6000
+
+feign:
+  hystrix:
+    enabled: true

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,3 +57,6 @@ services:
 
   monitoring:
     build: monitoring
+
+  turbine-stream-service:
+    build: turbine-stream-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,7 +163,21 @@ services:
         condition: service_healthy
     ports:
       - 9000:8080
-      - 8989:8989
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "10"
+
+  turbine-stream-service:
+    environment:
+      CONFIG_SERVICE_PASSWORD: $CONFIG_SERVICE_PASSWORD
+    image: sqshq/piggymetrics-turbine-stream-service
+    restart: always
+    depends_on:
+      config:
+        condition: service_healthy
+    ports:
+    - 8989:8989
     logging:
       options:
         max-size: "10m"

--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -4,4 +4,4 @@ MAINTAINER Alexander Lukyanchikov <sqshq@sqshq.com>
 ADD ./target/monitoring.jar /app/
 CMD ["java", "-Xmx200m", "-jar", "/app/monitoring.jar"]
 
-EXPOSE 8989 8080
+EXPOSE 8080

--- a/monitoring/pom.xml
+++ b/monitoring/pom.xml
@@ -22,17 +22,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-netflix-turbine-stream</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-stream-rabbit</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-hystrix-dashboard</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/monitoring/src/main/java/com/piggymetrics/monitoring/MonitoringApplication.java
+++ b/monitoring/src/main/java/com/piggymetrics/monitoring/MonitoringApplication.java
@@ -3,10 +3,8 @@ package com.piggymetrics.monitoring;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.netflix.hystrix.dashboard.EnableHystrixDashboard;
-import org.springframework.cloud.netflix.turbine.stream.EnableTurbineStream;
 
 @SpringBootApplication
-@EnableTurbineStream
 @EnableHystrixDashboard
 public class MonitoringApplication {
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 		<module>account-service</module>
 		<module>statistics-service</module>
 		<module>notification-service</module>
+		<module>turbine-stream-service</module>
 	</modules>
 
 </project>

--- a/turbine-stream-service/Dockerfile
+++ b/turbine-stream-service/Dockerfile
@@ -1,0 +1,7 @@
+FROM java:8-jre
+MAINTAINER Chi Dov <d.chiproeng@gmail.com>
+
+ADD ./target/turbine-stream-service.jar /app/
+CMD ["java", "-Xmx200m", "-jar", "/app/turbine-stream-service.jar"]
+
+EXPOSE 8989

--- a/turbine-stream-service/pom.xml
+++ b/turbine-stream-service/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>piggymetrics</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>turbine-stream-service</name>
+	<description>Turbine Stream Service</description>
+
+	<parent>
+		<groupId>com.piggymetrics</groupId>
+		<artifactId>piggymetrics</artifactId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-config</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-netflix-turbine-stream</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-stream-rabbit</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<finalName>${project.name}</finalName>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/turbine-stream-service/src/main/java/com/piggymetrics/turbine/TurbineStreamServiceApplication.java
+++ b/turbine-stream-service/src/main/java/com/piggymetrics/turbine/TurbineStreamServiceApplication.java
@@ -1,0 +1,16 @@
+package com.piggymetrics.turbine;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.netflix.turbine.stream.EnableTurbineStream;
+
+@SpringBootApplication
+@EnableTurbineStream
+@EnableDiscoveryClient
+public class TurbineStreamServiceApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(TurbineStreamServiceApplication.class, args);
+	}
+}

--- a/turbine-stream-service/src/main/resources/bootstrap.yml
+++ b/turbine-stream-service/src/main/resources/bootstrap.yml
@@ -1,0 +1,9 @@
+spring:
+  application:
+    name: turbine-stream-service
+  cloud:
+    config:
+      uri: http://config:8888
+      fail-fast: true
+      password: ${CONFIG_SERVICE_PASSWORD}
+      username: user

--- a/turbine-stream-service/src/test/java/com/piggymetrics/turbine/TurbineStreamServiceApplicationTests.java
+++ b/turbine-stream-service/src/test/java/com/piggymetrics/turbine/TurbineStreamServiceApplicationTests.java
@@ -1,0 +1,16 @@
+package com.piggymetrics.turbine;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class TurbineStreamServiceApplicationTests {
+
+	@Test
+	public void contextLoads() {
+	}
+
+}

--- a/turbine-stream-service/src/test/resources/bootstrap.yml
+++ b/turbine-stream-service/src/test/resources/bootstrap.yml
@@ -1,0 +1,3 @@
+eureka:
+  client:
+    enabled: false


### PR DESCRIPTION
After upgrade to spring-boot 2, some users report about hystrix dashboard is not accessable due to `IOException: Broken Pipe`.

The fix is to separate turbine-stream from monitoring service. and after the fix Hystrix Dashboard is working fine and we can monitor services through turbine stream.

<img width="676" alt="screen shot 2018-09-10 at 2 24 53 am" src="https://user-images.githubusercontent.com/5102972/45282565-e97f4800-b4a0-11e8-92b8-b098c5e7c81f.png">
