### PR TITLE
Fix Monitoring server port missing

### DIFF
--- a/config/src/main/resources/shared/monitoring.yml
+++ b/config/src/main/resources/shared/monitoring.yml
@@ -1,0 +1,2 @@
+server:
+  port: 9000


### PR DESCRIPTION
It should be 9000 according to README(https://github.com/sqshq/piggymetrics#important-endpoints), and it's missing from the config files