### PR TITLE
MongoDB container for windows (and mac) contributors

### DIFF
--- a/mongodb/Dockerfile
+++ b/mongodb/Dockerfile
@@ -6,9 +6,10 @@ ADD ./dump /
 
 RUN \
  chmod +x /init.sh && \
- apt-get update && apt-get dist-upgrade -y --force-yes && \
+ apt-get update && apt-get dist-upgrade -y --force-yes && apt-get install dos2unix && \
  apt-get install psmisc -y -q && \
  apt-get autoremove -y && apt-get clean && \
- rm -rf /var/cache/* && rm -rf /var/lib/apt/lists/*
+ rm -rf /var/cache/* && rm -rf /var/lib/apt/lists/* && \
+ dos2unix -n /init.sh /initx.sh && chmod +x /initx.sh
 
-ENTRYPOINT ["/init.sh"]
+ENTRYPOINT ["/initx.sh"]


### PR DESCRIPTION
When I launch MongoDb containers from a windows machine (using DockerTools vm) they stop working due to a problem when runing init.sh script.

After analyzing it seems that the problem is due to file formating of init.sh on windows. In fact, the OS adds a "bad" end of line that disturbs the execution of the script on linux.

The solution is to use [dos2unix](https://github.com/TizenTeam/dos2unix) to make sure the file is well formatted before executing it