### PR TITLE
Persist Auth

### DIFF
--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -20,6 +20,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>2.1.4.RELEASE</version>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
@@ -43,6 +48,11 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-sleuth</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>8.0.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/auth-service/src/main/java/com/piggymetrics/auth/config/OAuth2AuthorizationConfig.java
+++ b/auth-service/src/main/java/com/piggymetrics/auth/config/OAuth2AuthorizationConfig.java
@@ -3,8 +3,8 @@ package com.piggymetrics.auth.config;
 import com.piggymetrics.auth.service.security.MongoUserDetailsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
@@ -13,7 +13,8 @@ import org.springframework.security.oauth2.config.annotation.web.configuration.E
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
 import org.springframework.security.oauth2.provider.token.TokenStore;
-import org.springframework.security.oauth2.provider.token.store.InMemoryTokenStore;
+import org.springframework.security.oauth2.provider.token.store.JdbcTokenStore;
+import javax.sql.DataSource;
 
 /**
  * @author cdov
@@ -21,9 +22,6 @@ import org.springframework.security.oauth2.provider.token.store.InMemoryTokenSto
 @Configuration
 @EnableAuthorizationServer
 public class OAuth2AuthorizationConfig extends AuthorizationServerConfigurerAdapter {
-
-    private TokenStore tokenStore = new InMemoryTokenStore();
-    private final String NOOP_PASSWORD_ENCODE = "{noop}";
 
     @Autowired
     @Qualifier("authenticationManagerBean")
@@ -33,40 +31,22 @@ public class OAuth2AuthorizationConfig extends AuthorizationServerConfigurerAdap
     private MongoUserDetailsService userDetailsService;
 
     @Autowired
-    private Environment env;
+    private DataSource dataSource;
+
+    @Bean
+    public TokenStore tokenStore() {
+        return new JdbcTokenStore(dataSource);
+    }
 
     @Override
     public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
-
-        // TODO persist clients details
-
-        // @formatter:off
-        clients.inMemory()
-                .withClient("browser")
-                .authorizedGrantTypes("refresh_token", "password")
-                .scopes("ui")
-                .and()
-                .withClient("account-service")
-                .secret(env.getProperty("ACCOUNT_SERVICE_PASSWORD"))
-                .authorizedGrantTypes("client_credentials", "refresh_token")
-                .scopes("server")
-                .and()
-                .withClient("statistics-service")
-                .secret(env.getProperty("STATISTICS_SERVICE_PASSWORD"))
-                .authorizedGrantTypes("client_credentials", "refresh_token")
-                .scopes("server")
-                .and()
-                .withClient("notification-service")
-                .secret(env.getProperty("NOTIFICATION_SERVICE_PASSWORD"))
-                .authorizedGrantTypes("client_credentials", "refresh_token")
-                .scopes("server");
-        // @formatter:on
+        clients.jdbc(dataSource);
     }
 
     @Override
     public void configure(AuthorizationServerEndpointsConfigurer endpoints) throws Exception {
         endpoints
-                .tokenStore(tokenStore)
+                .tokenStore(tokenStore())
                 .authenticationManager(authenticationManager)
                 .userDetailsService(userDetailsService);
     }

--- a/config/src/main/resources/shared/account-service.yml
+++ b/config/src/main/resources/shared/account-service.yml
@@ -22,5 +22,10 @@ server:
   port: 6000
 
 feign:
+  client:
+    config:
+      default:
+        connectTimeout: 160000000
+        readTimeout: 160000000
   hystrix:
     enabled: true

--- a/config/src/main/resources/shared/auth-service.yml
+++ b/config/src/main/resources/shared/auth-service.yml
@@ -6,6 +6,14 @@ spring:
       password: ${MONGODB_PASSWORD}
       database: piggymetrics
       port: 27017
+  datasource:
+    url: jdbc:mysql://auth-mysql:3306/auth_mysql
+    username: user
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    database: mysql
 
 server:
   servlet:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,6 +25,11 @@ services:
     ports:
       - 25000:27017
 
+  auth-mysql:
+    build: mysql
+    ports:
+      - 3306:3306
+
   account-service:
     build: account-service
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
       STATISTICS_SERVICE_PASSWORD: $STATISTICS_SERVICE_PASSWORD
       ACCOUNT_SERVICE_PASSWORD: $ACCOUNT_SERVICE_PASSWORD
       MONGODB_PASSWORD: $MONGODB_PASSWORD
+      MYSQL_PASSWORD: $MYSQL_PASSWORD
     image: sqshq/piggymetrics-auth-service
     restart: always
     depends_on:
@@ -72,6 +73,19 @@ services:
       MONGODB_PASSWORD: $MONGODB_PASSWORD
     image: sqshq/piggymetrics-mongodb
     restart: always
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "10"
+
+  auth-mysql:
+    image: elkolotfi/piggymetrics-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: $MYSQL_PASSWORD
+      MYSQL_PASSWORD: $MYSQL_PASSWORD
+      ACCOUNT_SERVICE_PASSWORD: $ACCOUNT_SERVICE_PASSWORD
+      STATISTICS_SERVICE_PASSWORD: $STATISTICS_SERVICE_PASSWORD
+      NOTIFICATION_SERVICE_PASSWORD: $NOTIFICATION_SERVICE_PASSWORD
     logging:
       options:
         max-size: "10m"

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,0 +1,14 @@
+FROM mysql:5.7
+MAINTAINER Lotfi EL KORCHI <elkolotfi@gmail.com>
+
+ADD ./dump/ /
+ADD init.sh /
+
+RUN \
+ chmod +x /init.sh && \
+ apt-get update && apt-get dist-upgrade -y --force-yes && apt-get install dos2unix && \
+ apt-get install psmisc -y -q && \
+ apt-get autoremove -y && apt-get clean && \
+ rm -rf /var/cache/* && rm -rf /var/lib/apt/lists/* && \
+ dos2unix -n /init.sh /docker-entrypoint-initdb.d/initx.sh && \
+ chmod +x /docker-entrypoint-initdb.d/initx.sh

--- a/mysql/dump/init.sql
+++ b/mysql/dump/init.sql
@@ -1,0 +1,82 @@
+CREATE DATABASE auth_mysql;
+
+SET @q1 = concat('CREATE USER "user"@"localhost" IDENTIFIED BY "', @MYSQL_PASSWORD, '" ');
+PREPARE stmt FROM @q1; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+SET @q2 = concat('CREATE USER "user"@"%" IDENTIFIED BY "', @MYSQL_PASSWORD, '" ');
+PREPARE stmt2 FROM @q2; EXECUTE stmt2; DEALLOCATE PREPARE stmt2;
+
+GRANT SELECT ON auth_mysql.* to 'user'@'localhost';
+GRANT INSERT ON auth_mysql.* to 'user'@'localhost';
+GRANT DELETE ON auth_mysql.* to 'user'@'localhost';
+GRANT UPDATE ON auth_mysql.* to 'user'@'localhost';
+GRANT SELECT ON auth_mysql.* to 'user'@'%';
+GRANT INSERT ON auth_mysql.* to 'user'@'%';
+GRANT DELETE ON auth_mysql.* to 'user'@'%';
+GRANT UPDATE ON auth_mysql.* to 'user'@'%';
+
+USE auth_mysql
+
+create table if not exists oauth_client_details (
+  client_id VARCHAR(255) PRIMARY KEY,
+  resource_ids VARCHAR(255),
+  client_secret VARCHAR(255),
+  scope VARCHAR(255),
+  authorized_grant_types VARCHAR(255),
+  web_server_redirect_uri VARCHAR(255),
+  authorities VARCHAR(255),
+  access_token_validity INTEGER,
+  refresh_token_validity INTEGER,
+  additional_information VARCHAR(4096),
+  autoapprove VARCHAR(255)
+);
+
+create table if not exists oauth_client_token (
+  token_id VARCHAR(255),
+  token BLOB,
+  authentication_id VARCHAR(255) PRIMARY KEY,
+  user_name VARCHAR(255),
+  client_id VARCHAR(255)
+);
+
+create table if not exists oauth_access_token (
+  token_id VARCHAR(255),
+  token BLOB,
+  authentication_id VARCHAR(255) PRIMARY KEY,
+  user_name VARCHAR(255),
+  client_id VARCHAR(255),
+  authentication BLOB,
+  refresh_token VARCHAR(255)
+);
+
+create table if not exists oauth_refresh_token (
+  token_id VARCHAR(255),
+  token BLOB,
+  authentication BLOB
+);
+
+create table if not exists oauth_code (
+  code VARCHAR(255), authentication BLOB
+);
+
+create table if not exists oauth_approvals (
+    userId VARCHAR(255),
+    clientId VARCHAR(255),
+    scope VARCHAR(255),
+    status VARCHAR(10),
+    expiresAt TIMESTAMP DEFAULT  CURRENT_TIMESTAMP,
+    lastModifiedAt TIMESTAMP DEFAULT  CURRENT_TIMESTAMP
+);
+
+create table if not exists ClientDetails (
+  appId VARCHAR(255) PRIMARY KEY,
+  resourceIds VARCHAR(255),
+  appSecret VARCHAR(255),
+  scope VARCHAR(255),
+  grantTypes VARCHAR(255),
+  redirectUrl VARCHAR(255),
+  authorities VARCHAR(255),
+  access_token_validity INTEGER,
+  refresh_token_validity INTEGER,
+  additionalInformation VARCHAR(4096),
+  autoApproveScopes VARCHAR(255)
+);

--- a/mysql/dump/oauth_client_details.sql
+++ b/mysql/dump/oauth_client_details.sql
@@ -1,0 +1,11 @@
+SET @token_validity = 3600;
+
+INSERT INTO oauth_client_details
+    (client_id, client_secret, scope, authorized_grant_types, access_token_validity, additional_information)
+
+VALUES
+    ('browser', '', 'ui', 'refresh_token,password', @token_validity, '{}'),
+    ('account-service', @ACCOUNT_SERVICE_PASSWORD, 'server', 'client_credentials,refresh_token', @token_validity, '{}'),
+    ('statistics-service', @STATISTICS_SERVICE_PASSWORD, 'server', 'client_credentials,refresh_token', @token_validity, '{}'),
+    ('notification-service', @NOTIFICATION_SERVICE_PASSWORD, 'server', 'client_credentials,refresh_token', @token_validity, '{}')
+    ;

--- a/mysql/init.sh
+++ b/mysql/init.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "setup env variables in MySQL"
+init_vars=(
+    'SET @ACCOUNT_SERVICE_PASSWORD = '"'$ACCOUNT_SERVICE_PASSWORD'"'; '
+    'SET @STATISTICS_SERVICE_PASSWORD = '"'$STATISTICS_SERVICE_PASSWORD'"'; '
+    'SET @NOTIFICATION_SERVICE_PASSWORD = '"'$NOTIFICATION_SERVICE_PASSWORD'"';'
+    'SET @MYSQL_PASSWORD = '"'$MYSQL_PASSWORD'"';'
+)
+# Join the array init_vars in a string and add oauth_client_details.sql content to it
+query="$(IFS=; echo "${init_vars[*]}") $(< init.sql) $(< oauth_client_details.sql)"
+
+# Store content of query inside a temporary file
+tmp_file=$(mktemp /tmp/duplicate.XXXXXXX --suffix vars.sql)
+echo "${query}" > "${tmp_file}"
+
+echo "Run sql scripts"
+mysql -uroot -p${MYSQL_PASSWORD} < "${tmp_file}"
+
+# Remove temporary file
+rm "${tmp_file}"


### PR DESCRIPTION
Actually, client details and tokens are stored in memory. Naturally this is not the best as it creates a strong coupling between the service and the data it manages.

Hence, I made this pull request to manage the authentication data on a separate container. I also shared the image on a docker repo (feel free to use your own repo if you prefer).

At your disposition for further information and/or discussion :)