### PR TITLE
Revert "Fix Monitoring server port missing"

### DIFF
--- a/config/src/main/resources/shared/monitoring.yml
+++ b/config/src/main/resources/shared/monitoring.yml
@@ -1,2 +1,0 @@
-server:
-  port: 9000


### PR DESCRIPTION
This reverts commit d3beabc5

docker-compose ports section has mapping <host>:<container>
so specified port with 9000 brought to wrong port mapping therefore dashboard is not available