### PR TITLE
Hystrix Dasboard not working 

### DIFF
--- a/config/src/main/resources/shared/application.yml
+++ b/config/src/main/resources/shared/application.yml
@@ -25,3 +25,8 @@ security:
 spring:
   rabbitmq:
     host: rabbitmq
+    
+management: 
+  web:
+    exposure:
+      include: "*"     

--- a/config/src/main/resources/shared/turbine-stream-service.yml
+++ b/config/src/main/resources/shared/turbine-stream-service.yml
@@ -1,0 +1,2 @@
+server:
+  port: 8989


### PR DESCRIPTION
1. 
Turbine stream app currently is running on 8080 but in compose file we have 8989
see https://github.com/sqshq/piggymetrics/blob/master/docker-compose.yml 

2.
Apart of it actuator/hystrix.stream metrics were missing. All those issue could be related to Spring versions as we dont enforce specific one...