### PR TITLE
add dependency to maven

### DIFF
--- a/account-service/pom.xml
+++ b/account-service/pom.xml
@@ -81,6 +81,16 @@
 			<version>2.2.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.0</version> <!-- Use the latest version available -->
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>2.3.3</version>
+		</dependency>
 	</dependencies>
 	
 	<build>


### PR DESCRIPTION
These dependencies(jaxb-api and jaxb-impl) solve the error " Implementation of JAXB-API has not been found on module path or classpath."
I develop the account-service and when I run the service locally, the error appears.